### PR TITLE
Removes hardcoded uid for git user

### DIFF
--- a/src/ansible/roles/local/system/tasks/main.yml
+++ b/src/ansible/roles/local/system/tasks/main.yml
@@ -4,7 +4,6 @@
 - name: Add the git user
   user:
     name: git
-    uid: 1000
     home: "{{ lookup('env', 'GIT_ROOT') }}"
     shell: /bin/bash
     groups: docker


### PR DESCRIPTION
Fixes #90 (untested)

uid is an optional parameter during user creation, checked on Ansible docs