### PR TITLE
Fix installation for Ubuntu 22.04 LTS (jammy)

### DIFF
--- a/src/ansible/inventory/inventory.yml
+++ b/src/ansible/inventory/inventory.yml
@@ -7,7 +7,7 @@ all:
     ansible_ssh_known_hosts: '/mnt/{{ gluster_volume_name }}/ansible/.ssh/known_hosts'
     docker_group: docker
     local_user: "{{ lookup('env', 'USER') }}"
-    gluster_version: 7
+    gluster_version: 10
     gluster_volume_name: gfs
     gluster_brick_path:
       - '/data/glusterfs/brick01/{{ gluster_volume_name }}'

--- a/src/ansible/playbooks/gluster.yml
+++ b/src/ansible/playbooks/gluster.yml
@@ -6,4 +6,4 @@
     - disk
     - role: glusterfs
       vars:
-        gluster_version: 7
+        gluster_version: 10

--- a/src/ansible/plugins/docker_swarm.yml
+++ b/src/ansible/plugins/docker_swarm.yml
@@ -1,2 +1,2 @@
-plugin: community.general.docker_swarm
+plugin: community.docker.docker_swarm
 docker_host: unix://var/run/docker.sock

--- a/src/ansible/roles/local/common/tasks/main.yml
+++ b/src/ansible/roles/local/common/tasks/main.yml
@@ -21,16 +21,36 @@
   ignore_errors: yes
   when: "'/etc/cloud/templates/hosts.debian.tmpl' is file"
 
+- name: update apt cache
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+  register: result
+  until: result is not failed
+  retries: 5
+  delay: 5
+
 - name: install pip
   apt:
     pkg:
       - python3-pip
+  register: result
+  until: result is not failed
+  retries: 5
+  delay: 5
 
 - name: Remove unused apt packages from the cache
   apt:
     autoclean: yes
-  ignore_errors: yes
+  register: result
+  until: result is not failed
+  retries: 5
+  delay: 5
 
 - name: Remove dependencies that are no longer required
   apt:
     autoremove: yes
+  register: result
+  until: result is not failed
+  retries: 5
+  delay: 5

--- a/src/ansible/roles/local/common/tasks/main.yml
+++ b/src/ansible/roles/local/common/tasks/main.yml
@@ -29,6 +29,7 @@
 - name: Remove unused apt packages from the cache
   apt:
     autoclean: yes
+  ignore_errors: yes
 
 - name: Remove dependencies that are no longer required
   apt:

--- a/src/ansible/roles/requirements.yml
+++ b/src/ansible/roles/requirements.yml
@@ -1,7 +1,6 @@
 ---
 collections:
-  - name: acl
-    src: ansible.posix.acl
+  - ansible.posix
 
 roles:
   - name: swap


### PR DESCRIPTION
Resolves two issues that were preventing my installation process from completing successfully on a stock Ubuntu 22.04 image:
1. Invalid syntax for collection specification in src/ansible/roles/requirements.yml:
  As pointed out by @sergioisidoro, Ansible's spec for providing collection dependencies appears to differ from its spec for providing role dependencies. For one, `src` is not a valid key as it is with role dependencies. And for two, the full dependency was being named (`ansible.posix.acl`) when merely the collection (`ansible.posix`) is wanted. The simplified syntax present in their documentation solves this issue.
2. GlusterFS version 7 has no release for Ubuntu 22.04 (jammy). Upgrading the version requirement from 7 to 10 appears to have had no negative effects on my deployment, and provides a usable release that permits the installation to continue.

Re-provisioning my 22.04 host and installing from my branch now provides a functioning Swarmlet instance.

This resolves the "name on collections" and "glusterfs" issues of #137